### PR TITLE
Remove react-tap-event-plugin due to deprecation in later versions of…

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,8 +5,6 @@ import "./styles/styles.css";
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
-import injectTapEventPlugin from "react-tap-event-plugin";
-injectTapEventPlugin();
 
 import VideoComponent from './VideoComponent';
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "material-ui": "^0.20.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-tap-event-plugin": "^3.0.2",
     "twilio": "^3.11.1",
     "twilio-video": "^1.7.0",
     "webpack": "^3.8.1"


### PR DESCRIPTION
React no longer supports react-tap-event-plugin and plugin itself suggests removal and deprecation: https://github.com/zilverline/react-tap-event-plugin. Application won't work if trying to install locally while also having plugin in package.json. 